### PR TITLE
fix: do not crash when logging circular objects

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+Due to using `util.inspect` instead of `JSON.stringify`, the output of the log
+functions has changed:
+
+- Log single quotes instead of double quotes in array and object values.
+- No longer quotes property names in objects.
+- Does not always include newlines in arrays and objects.
+
+### Fixed
+
+- Logging circular references no longer causes a crash.
+
 ## [0.1.0]: 2024-01-24Z
 
 ### Added

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -26,19 +26,23 @@ function testLogMethod (methodName: 'info' | 'warn' | 'error'): void {
     it('should log an object', async () => {
       const output = await logMethod({ a: 'b' }, true)
       expect(output).toMatch(
-        new RegExp(
-          patternPrefix + `\\{\\n${paddingPattern}  "a": "b"\\n${paddingPattern}\\}$`
-        )
+        new RegExp(patternPrefix + /\{ a: 'b' \}$/.source)
+      )
+    })
+
+    it('should log a circular object', async () => {
+      const circular: any = {}
+      circular.a = circular
+      const output = await logMethod(circular, true)
+      expect(output).toMatch(
+        new RegExp(patternPrefix + /<ref \*1> \{ a: \[Circular \*1] \}$/.source)
       )
     })
 
     it('should log an array', async () => {
       const output = await logMethod(['a', 'b'], true)
       expect(output).toMatch(
-        new RegExp(
-          patternPrefix +
-            `\\[\\n${paddingPattern}  "a",\\n${paddingPattern}  "b"\\n${paddingPattern}\\]$`
-        )
+        new RegExp(patternPrefix + /\[ 'a', 'b' \]$/.source)
       )
     })
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import fs from 'fs/promises'
+import { inspect } from 'util'
 
 let logPath = ''
 
@@ -31,7 +32,7 @@ async function log (message: unknown, type: LogType, dry = false): Promise<strin
       processedMessage += message
       break
     case 'object':
-      processedMessage += JSON.stringify(message, null, 2)
+      processedMessage += inspect(message)
       break
     case 'undefined':
       processedMessage += 'undefined'


### PR DESCRIPTION
Implement `utils.inspect` to replace `JSON.stringify` and fix crashes when trying to log circular objects.

Close #1 